### PR TITLE
Add Semgrep Rules For AuthZ/IDOR Regression Detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,33 @@ jobs:
           python -m pip install yamllint
           yamllint -d "{extends: default, rules: {document-start: disable, truthy: disable, comments: disable, line-length: disable}}" .github/workflows
 
+  semgrep-authz-idor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install Semgrep
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install semgrep
+
+      - name: Run custom AuthZ/IDOR rules
+        run: |
+          semgrep \
+            --config .semgrep/rules/authz-idor.yml \
+            --error \
+            --exclude .git \
+            --exclude .github \
+            --exclude .semgrep \
+            .
+
   flutter:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.semgrep/rules/authz-idor.yml
+++ b/.semgrep/rules/authz-idor.yml
@@ -1,0 +1,43 @@
+rules:
+  - id: shamell.authz.wallet-query-missing-actor-scope
+    message: >
+      Potential wallet-scoped query without actor/user ownership checks.
+      Enforce wallet_id + actor/user scoping in the same query or authz guard.
+    severity: ERROR
+    languages: [python, javascript, typescript, go, dart]
+    metadata:
+      category: security
+      cwe: "CWE-639: Authorization Bypass Through User-Controlled Key"
+      owasp: "A01:2021 - Broken Access Control"
+      confidence: medium
+    patterns:
+      - pattern-regex: (?is)\b(SELECT|UPDATE|DELETE)\b[\s\S]{0,500}\bWHERE\b[\s\S]{0,250}\bwallet_id\b
+      - pattern-not-regex: (?is)\b(actor_id|user_id|owner_id|account_id)\b
+
+  - id: shamell.authz.trusting-client-internal-headers
+    message: >
+      Potential trust of client-provided internal header detected.
+      Treat x-internal/x-service/x-admin headers as untrusted unless verified via gateway/mTLS.
+    severity: ERROR
+    languages: [python, javascript, typescript, go, dart]
+    metadata:
+      category: security
+      cwe: "CWE-345: Insufficient Verification of Data Authenticity"
+      owasp: "A01:2021 - Broken Access Control"
+      confidence: medium
+    pattern-regex: (?is)\b(req|request|ctx)\b[\s\S]{0,120}\b(headers|get|header)\b[\s\S]{0,120}["']x-(internal|service|admin)[^"']*["']
+
+  - id: shamell.injection.unsafe-token-query-construction
+    message: >
+      Potential unsafe query construction using token fields with concatenation/interpolation.
+      Use parameterized statements and validated bind variables.
+    severity: ERROR
+    languages: [python, javascript, typescript, go, dart]
+    metadata:
+      category: security
+      cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command"
+      owasp: "A03:2021 - Injection"
+      confidence: medium
+    patterns:
+      - pattern-regex: (?is)\b(sql|query)\b\s*[:=]\s*["'`]?[\s\S]{0,200}\b(token|auth_token|session_token|refresh_token)\b
+      - pattern-regex: (?is)(\+|\$\{|format\(|f["'])

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Shamell
 
 Security project bootstrap (2026-02-06).
+
+## Semgrep AuthZ/IDOR Rules
+
+Custom regression rules live in `.semgrep/rules/authz-idor.yml` and target:
+- wallet-scoped queries without actor/user ownership checks
+- trust of client-provided internal headers
+- unsafe token query construction patterns
+
+Run locally:
+
+```bash
+python -m pip install semgrep
+semgrep --config .semgrep/rules/authz-idor.yml --error .
+```


### PR DESCRIPTION
## Summary
- add targeted Semgrep rules for wallet actor scoping, internal header trust, and unsafe token query patterns
- run custom Semgrep rules in CI as semgrep-authz-idor
- document local Semgrep invocation in README

Closes #4