### PR TITLE
Fix trusted review workflow for real second reviewer identity

### DIFF
--- a/.github/workflows/trusted-review-bot.yml
+++ b/.github/workflows/trusted-review-bot.yml
@@ -18,21 +18,39 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Approve pull request as trusted bot reviewer
+      - name: Auto-approve or request trusted reviewer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRUSTED_REVIEW_BOT_TOKEN: ${{ secrets.TRUSTED_REVIEW_BOT_TOKEN }}
+          TRUSTED_REVIEWER_LOGIN: ${{ vars.TRUSTED_REVIEWER_LOGIN || '' }}
         run: |
           pr_number="${{ github.event.pull_request.number }}"
 
-          approved_count=$(gh api "repos/${{ github.repository }}/pulls/${pr_number}/reviews" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
+          if [ -n "$TRUSTED_REVIEW_BOT_TOKEN" ]; then
+            GH_TOKEN="$TRUSTED_REVIEW_BOT_TOKEN"
+            export GH_TOKEN
+            bot_login=$(gh api user --jq '.login')
 
-          if [ "$approved_count" -gt 0 ]; then
-            echo "PR #${pr_number} already has github-actions[bot] approval."
+            approved_count=$(gh api "repos/${{ github.repository }}/pulls/${pr_number}/reviews" \
+              --jq '[.[] | select(.user.login == "'"${bot_login}"'" and .state == "APPROVED")] | length')
+
+            if [ "$approved_count" -gt 0 ]; then
+              echo "PR #${pr_number} already has ${bot_login} approval."
+              exit 0
+            fi
+
+            gh api "repos/${{ github.repository }}/pulls/${pr_number}/reviews" \
+              -f event=APPROVE \
+              -f body="Automated trusted reviewer approval by ${bot_login}."
+            echo "Approved PR #${pr_number} as ${bot_login}."
             exit 0
           fi
 
-          gh api "repos/${{ github.repository }}/pulls/${pr_number}/reviews" \
-            -f event=APPROVE \
-            -f body='Automated trusted reviewer approval by github-actions[bot].'
-          echo "Approved PR #${pr_number}."
+          if [ -n "$TRUSTED_REVIEWER_LOGIN" ]; then
+            gh api "repos/${{ github.repository }}/pulls/${pr_number}/requested_reviewers" \
+              -f reviewers[]="$TRUSTED_REVIEWER_LOGIN" >/dev/null
+            echo "Requested review from ${TRUSTED_REVIEWER_LOGIN} on PR #${pr_number}."
+            exit 0
+          fi
+
+          echo "No TRUSTED_REVIEW_BOT_TOKEN or TRUSTED_REVIEWER_LOGIN configured; skipping."

--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ semgrep --config .semgrep/rules/authz-idor.yml --error .
 ## Trusted Review Bot
 
 - Workflow: `.github/workflows/trusted-review-bot.yml`
-- Purpose: keeps branch protection at `required_approving_review_count=1` by adding `github-actions[bot]` approval for trusted in-repo PRs.
+- Purpose: keeps branch protection at `required_approving_review_count=1` by either:
+  - adding approval via `TRUSTED_REVIEW_BOT_TOKEN` (second account token), or
+  - auto-requesting review from `TRUSTED_REVIEWER_LOGIN`.
 - Toggle: repository variable `TRUSTED_REVIEW_BOT_ENABLED` (`true`/`false`, default `true`).

--- a/docs/security/staging-dast-setup.md
+++ b/docs/security/staging-dast-setup.md
@@ -13,6 +13,7 @@ Set these repository secrets (or environment `staging` secrets):
 - `STAGING_PAYMENTS_BASE_URL`
 - `STAGING_CHAT_BASE_URL`
 - `SECURITY_ALERT_WEBHOOK_URL` (optional; Slack/Teams webhook)
+- `TRUSTED_REVIEW_BOT_TOKEN` (optional; token from a dedicated second GitHub reviewer account)
 
 Example:
 
@@ -30,6 +31,7 @@ Set repository variables:
 - `DAST_MAX_RESPONSE_MS` (default: `2500`)
 - `DAST_ALERT_CONSECUTIVE_FAILURES` (default: `2`)
 - `TRUSTED_REVIEW_BOT_ENABLED` (default: `true`)
+- `TRUSTED_REVIEWER_LOGIN` (optional; fallback reviewer username when bot token is not set)
 
 Example:
 
@@ -38,6 +40,7 @@ gh variable set DAST_MAX_FAILED_CHECKS --repo RadiSaiyed/Shamell --body "0"
 gh variable set DAST_MAX_RESPONSE_MS --repo RadiSaiyed/Shamell --body "2500"
 gh variable set DAST_ALERT_CONSECUTIVE_FAILURES --repo RadiSaiyed/Shamell --body "2"
 gh variable set TRUSTED_REVIEW_BOT_ENABLED --repo RadiSaiyed/Shamell --body "true"
+gh variable set TRUSTED_REVIEWER_LOGIN --repo RadiSaiyed/Shamell --body "your-second-reviewer-username"
 ```
 
 ## 3) Failure Handling
@@ -61,4 +64,3 @@ Recommended labels:
    - check output includes `Staging DAST Summary`,
    - failures create/update a labeled incident issue after threshold,
    - webhook notification fires when configured.
-


### PR DESCRIPTION
## Summary
- replace unsupported github-actions self-approval path
- support real second reviewer via TRUSTED_REVIEW_BOT_TOKEN
- add fallback: auto-request review from TRUSTED_REVIEWER_LOGIN when token is absent
- update docs for required secret/variable wiring