### PR TITLE
Harden CORS smoke policy controls and wildcard handling

### DIFF
--- a/.github/workflows/cors-preflight-smoke.yml
+++ b/.github/workflows/cors-preflight-smoke.yml
@@ -39,6 +39,8 @@ jobs:
           SMOKE_MAX_FAILED_CHECKS: ${{ vars.CORS_PREFLIGHT_MAX_FAILED_CHECKS || '0' }}
           SMOKE_TIMEOUT_SECS: ${{ vars.CORS_PREFLIGHT_TIMEOUT_SECS || '15' }}
           SMOKE_CONNECT_TIMEOUT_SECS: ${{ vars.CORS_PREFLIGHT_CONNECT_TIMEOUT_SECS || '5' }}
+          SMOKE_REQUIRE_REQUEST_ID: ${{ vars.CORS_PREFLIGHT_REQUIRE_REQUEST_ID || 'true' }}
+          SMOKE_ALLOW_WILDCARD_ALLOW_HEADERS: ${{ vars.CORS_PREFLIGHT_STAGING_ALLOW_WILDCARD_ALLOW_HEADERS || 'false' }}
           SMOKE_USER_AGENT: "shamell-cors-preflight-smoke/staging"
         run: |
           bash ./scripts/cors_preflight_smoke.sh
@@ -61,6 +63,8 @@ jobs:
           SMOKE_MAX_FAILED_CHECKS: ${{ vars.CORS_PREFLIGHT_MAX_FAILED_CHECKS || '0' }}
           SMOKE_TIMEOUT_SECS: ${{ vars.CORS_PREFLIGHT_TIMEOUT_SECS || '15' }}
           SMOKE_CONNECT_TIMEOUT_SECS: ${{ vars.CORS_PREFLIGHT_CONNECT_TIMEOUT_SECS || '5' }}
+          SMOKE_REQUIRE_REQUEST_ID: ${{ vars.CORS_PREFLIGHT_REQUIRE_REQUEST_ID || 'true' }}
+          SMOKE_ALLOW_WILDCARD_ALLOW_HEADERS: ${{ vars.CORS_PREFLIGHT_PROD_ALLOW_WILDCARD_ALLOW_HEADERS || 'false' }}
           SMOKE_USER_AGENT: "shamell-cors-preflight-smoke/production"
         run: |
           bash ./scripts/cors_preflight_smoke.sh

--- a/docs/security/online-smoke.md
+++ b/docs/security/online-smoke.md
@@ -47,6 +47,9 @@ Required secrets/vars:
   - `CORS_PREFLIGHT_MAX_FAILED_CHECKS` (default: `0`)
   - `CORS_PREFLIGHT_TIMEOUT_SECS` (default: `15`)
   - `CORS_PREFLIGHT_CONNECT_TIMEOUT_SECS` (default: `5`)
+  - `CORS_PREFLIGHT_REQUIRE_REQUEST_ID` (default: `true`)
+  - `CORS_PREFLIGHT_STAGING_ALLOW_WILDCARD_ALLOW_HEADERS` (default: `false`)
+  - `CORS_PREFLIGHT_PROD_ALLOW_WILDCARD_ALLOW_HEADERS` (default: `false`)
 
 ## Remote smoke (optional)
 


### PR DESCRIPTION
## Summary
- make CORS preflight smoke robust against bash broken-pipe noise
- add explicit wildcard allow-headers policy (`SMOKE_ALLOW_WILDCARD_ALLOW_HEADERS`)
- add rollout toggle for x-request-id requirement (`SMOKE_REQUIRE_REQUEST_ID`)
- wire new controls into workflow vars for staging/prod
- document new vars in online smoke docs

## Why
Current online envs are mixed during rollout: staging lacks `x-request-id` in some CORS allow-lists and production still returns `Access-Control-Allow-Headers: *`. This patch keeps strict defaults while allowing explicit, auditable transition toggles per environment.

## Validation
- `bash -n scripts/cors_preflight_smoke.sh`
- staging smoke passes with `SMOKE_REQUIRE_REQUEST_ID=false`
- production smoke fails with clear wildcard-policy message unless override is explicitly enabled
